### PR TITLE
Fix canonical metadata and sitemap for indexing

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -101,7 +101,7 @@ function generateSitemapXml(urls) {
         xml += '  </url>\n';
     });
 
-    xml += '</urlset>';
+    xml += '</urlset>\n';
     return xml;
 }
 
@@ -116,13 +116,21 @@ function main() {
 
     // Generate sitemap content
     const urls = generatePageUrls();
+
+    // Sort URLs alphabetically for deterministic output
+    urls.sort((a, b) => a.url.localeCompare(b.url));
+
     const sitemapContent = generateSitemapXml(urls);
 
     // Write sitemap to dist directory
     const sitemapPath = path.join(distDir, 'sitemap.xml');
     fs.writeFileSync(sitemapPath, sitemapContent);
-
     console.log(`Sitemap generated at ${sitemapPath}`);
+
+    // Also write to project root so the canonical sitemap stays in sync
+    const rootSitemapPath = path.join(rootDir, 'sitemap.xml');
+    fs.writeFileSync(rootSitemapPath, sitemapContent);
+    console.log(`Sitemap synced at ${rootSitemapPath}`);
 }
 
 main();

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,168 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url>
-<loc>https://jsreact.com</loc>
-<lastmod>2025-05-05T01:40:19-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/analytics</loc>
-<lastmod>2025-05-08T20:57:31-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/clean</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/diff</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/domain</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/expression</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/generator</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/insert</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/keyword</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/minify</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/osrs</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/playground</loc>
-<lastmod>2025-05-15T12:10:45-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/policy</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/qr</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/speech</loc>
-<lastmod>2025-05-02T21:14:09-07:00</lastmod>
-</url>
-<url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/bitmapper.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/bitpacker.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/chunkstream.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/constants.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/crc.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/filter-pack.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/filter-parse-async.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/filter-parse-sync.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/filter-parse.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/format-normaliser.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/interlace.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/packer-async.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/packer-sync.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/packer.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/paeth-predictor.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/parser-async.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/parser-sync.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/parser.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/png-sync.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/png.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/sync-inflate.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/pngjs/coverage/lcov-report/sync-reader.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/random-seed/coverage/lcov-report</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/random-seed/coverage/lcov-report/random-seed</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
-<url>
-<loc>https://jsreact.com/node_modules/random-seed/coverage/lcov-report/random-seed/index.js.html</loc>
-<lastmod>2025-05-16T05:43:59+00:00</lastmod>
-</url>
+  <url>
+    <loc>https://jsreact.com/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/analytics/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/clean/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/diff/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/domain/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/elevation/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/expression/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/generator/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/insert/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/keyword/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/minify/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/osrs/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/playground/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/policy/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/qr/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/speech/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/src/analytics/index.html
+++ b/src/analytics/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <script type="module">
             import { createHead } from '@components/head.js';
             createHead(

--- a/src/clean/index.html
+++ b/src/clean/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <script type="module">
             import { createHead } from '@components/head.js';
             createHead(

--- a/src/components/head.js
+++ b/src/components/head.js
@@ -48,7 +48,7 @@ export function createHead(title, description, options = {}) {
         return null;
     }
 
-    const head = document.getElementsByTagName('head')[0];
+    const head = document.head;
     if (!head) {
         console.error('Head element not found');
         return null;
@@ -56,90 +56,148 @@ export function createHead(title, description, options = {}) {
 
     const {
         gaTrackingId = 'G-ZEFG04PXR7',
-        baseUrl = window.location.origin,
-        publishDate = new Date().toISOString().split('T')[0]
+        baseUrl: providedBaseUrl,
+        publishDate = new Date().toISOString().split('T')[0],
+        canonicalPath
     } = options;
 
-    // Utility for safe URL construction
+    const defaultBaseUrl = providedBaseUrl ||
+        (['localhost', '127.0.0.1'].includes(window.location.hostname)
+            ? 'https://jsreact.com'
+            : window.location.origin);
+
     const getFullUrl = (path) => {
         try {
-            return new URL(path, baseUrl).toString();
+            return new URL(path, defaultBaseUrl).toString();
         } catch (e) {
             console.error(`Invalid URL construction: ${path}`, e);
-            return `${baseUrl}${path}`;
+            return `${defaultBaseUrl}${path}`;
+        }
+    };
+
+    const ensureCriticalStyles = () => {
+        if (head.querySelector('style[data-jsreact-critical="true"]')) {
+            return;
+        }
+
+        const criticalStyles = document.createElement('style');
+        criticalStyles.dataset.jsreactCritical = 'true';
+        criticalStyles.textContent = `
+            .js-loading { opacity: 0; }
+            .js-ready { opacity: 1; transition: opacity 0.3s; }
+            body {
+                margin: 0;
+                font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
+                opacity: 0;
+                transition: opacity 0.3s;
+            }
+            @keyframes spin { to { transform: rotate(360deg); } }
+            @keyframes slide-up {
+                from { opacity: 0; transform: translateY(20px); }
+                to { opacity: 1; transform: translateY(0); }
+            }
+            .animate-slide-up { animation: slide-up 0.8s ease-out forwards; }
+        `;
+        head.insertBefore(criticalStyles, head.firstChild);
+    };
+
+    const appendExternalResource = (resource) => {
+        const { type, rel, href, src } = resource;
+        const selector = type === 'link'
+            ? `link[rel="${rel}"][href="${href}"]`
+            : type === 'script'
+                ? `script[src="${src}"]`
+                : '';
+
+        if (selector && head.querySelector(selector)) {
+            return;
+        }
+
+        const el = document.createElement(type);
+        Object.entries(resource).forEach(([key, value]) => {
+            if (key !== 'type' && value !== undefined) {
+                el.setAttribute(key, value);
+            }
+        });
+        head.appendChild(el);
+    };
+
+    const setMetaTag = (attributes) => {
+        const { name, property, charset, httpEquiv, content } = attributes;
+        let selector = '';
+
+        if (charset) {
+            selector = 'meta[charset]';
+        } else if (name) {
+            selector = `meta[name="${name}"]`;
+        } else if (property) {
+            selector = `meta[property="${property}"]`;
+        } else if (httpEquiv) {
+            selector = `meta[http-equiv="${httpEquiv}"]`;
+        }
+
+        let tag = selector ? head.querySelector(selector) : null;
+
+        if (!tag) {
+            tag = document.createElement('meta');
+            if (charset && head.firstChild) {
+                head.insertBefore(tag, head.firstChild);
+            } else {
+                head.appendChild(tag);
+            }
+        }
+
+        if (charset) {
+            tag.setAttribute('charset', charset);
+            return;
+        }
+
+        if (name) {
+            tag.setAttribute('name', name);
+        }
+        if (property) {
+            tag.setAttribute('property', property);
+        }
+        if (httpEquiv) {
+            tag.setAttribute('http-equiv', httpEquiv);
+        }
+        if (content !== undefined) {
+            tag.setAttribute('content', content);
         }
     };
 
     // Set document title
     document.title = `${title} | JSreact`;
 
-    // Critical styles for performance
-    const criticalStyles = document.createElement('style');
-    criticalStyles.textContent = `
-        .js-loading { opacity: 0; }
-        .js-ready { opacity: 1; transition: opacity 0.3s; }
-        body {
-            margin: 0;
-            font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
-            opacity: 0;
-            transition: opacity 0.3s;
-        }
-        @keyframes spin { to { transform: rotate(360deg); } }
-        @keyframes slide-up {
-            from { opacity: 0; transform: translateY(20px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-        .animate-slide-up { animation: slide-up 0.8s ease-out forwards; }
-    `;
-    head.insertBefore(criticalStyles, head.firstChild);
+    ensureCriticalStyles();
 
-    // Load external resources
-    const externalResources = [
-        {
-            type: 'link',
-            rel: 'manifest',
-            href: '/manifest.json'
-        },
-        {
-            type: 'link',
-            rel: 'manifest',
-            href: '/site.webmanifest'
-        },
+    [
+        { type: 'link', rel: 'manifest', href: '/manifest.json' },
+        { type: 'link', rel: 'manifest', href: '/site.webmanifest' },
         {
             type: 'link',
             rel: 'stylesheet',
             href: 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css',
-            crossOrigin: 'anonymous',
-            referrerPolicy: 'no-referrer'
+            crossorigin: 'anonymous',
+            referrerpolicy: 'no-referrer'
         },
-        {
-            type: 'link',
-            rel: 'preconnect',
-            href: 'https://fonts.googleapis.com'
-        },
-        {
-            type: 'link',
-            rel: 'preconnect',
-            href: 'https://fonts.gstatic.com',
-            crossOrigin: 'anonymous'
-        }
-    ];
+        { type: 'link', rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+        { type: 'link', rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: 'anonymous' }
+    ].forEach(appendExternalResource);
 
-    externalResources.forEach(resource => {
-        const el = document.createElement(resource.type);
-        Object.entries(resource).forEach(([key, value]) => {
-            if (key !== 'type') el.setAttribute(key, value);
-        });
-        head.appendChild(el);
-    });
+    const currentUrl = new URL(window.location.href);
+    let canonicalTarget = canonicalPath || currentUrl.pathname;
+    if (!canonicalTarget.endsWith('/') && !canonicalTarget.includes('.')) {
+        canonicalTarget += '/';
+    }
+    const canonicalUrl = getFullUrl(canonicalTarget);
 
-    // Add canonical URL
+    head.querySelectorAll('link[rel="canonical"]').forEach(link => link.remove());
     const canonicalLink = document.createElement('link');
     canonicalLink.rel = 'canonical';
-    canonicalLink.href = window.location.href.split('?')[0].split('#')[0]; // Remove query params and hash
+    canonicalLink.href = canonicalUrl;
     head.appendChild(canonicalLink);
 
-    // Meta tags
     const metaTags = [
         { charset: 'UTF-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1.0' },
@@ -151,7 +209,7 @@ export function createHead(title, description, options = {}) {
         { property: 'og:type', content: 'website' },
         { property: 'og:title', content: `${title} | JSreact` },
         { property: 'og:description', content: description },
-        { property: 'og:url', content: window.location.href },
+        { property: 'og:url', content: canonicalUrl },
         { property: 'og:site_name', content: 'JSreact' },
         { property: 'og:image', content: getFullUrl('/assets/images/og-image.png') },
         { property: 'og:image:width', content: '1200' },
@@ -162,30 +220,16 @@ export function createHead(title, description, options = {}) {
         { name: 'twitter:image', content: getFullUrl('/assets/images/og-image.png') }
     ];
 
-    // Clear existing meta tags
-    head.querySelectorAll('meta').forEach(meta => meta.remove());
+    metaTags.forEach(setMetaTag);
 
-    // Add meta tags
-    metaTags.forEach(meta => {
-        const tag = document.createElement('meta');
-        Object.entries(meta).forEach(([key, value]) => tag.setAttribute(key, value));
-        head.appendChild(tag);
-    });
-
-    // Set canonical URL
-    const canonical = document.createElement('link');
-    canonical.rel = 'canonical';
-    canonical.href = window.location.href;
-    head.appendChild(canonical);
-
-    // Add Google Analytics if enabled
-    if (gaTrackingId) {
+    if (gaTrackingId && !head.querySelector(`script[src*="gtag/js?id=${gaTrackingId}"]`)) {
         const gaScript = document.createElement('script');
         gaScript.async = true;
         gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`;
         head.appendChild(gaScript);
 
         const gaInit = document.createElement('script');
+        gaInit.dataset.jsreactGtag = 'true';
         gaInit.textContent = `
             window.dataLayer = window.dataLayer || [];
             function gtag() { dataLayer.push(arguments); }
@@ -195,20 +239,19 @@ export function createHead(title, description, options = {}) {
         head.appendChild(gaInit);
     }
 
-    // Structured data
     const structuredData = {
         '@context': 'https://schema.org',
         '@type': 'WebApplication',
         name: 'JSreact',
         headline: title,
         description: description,
-        url: window.location.href,
+        url: canonicalUrl,
         applicationCategory: 'DeveloperApplication',
         operatingSystem: 'Any',
         author: {
             '@type': 'Organization',
             name: 'JSreact',
-            url: baseUrl,
+            url: defaultBaseUrl,
             logo: {
                 '@type': 'ImageObject',
                 url: getFullUrl('/assets/images/icon.png')
@@ -218,13 +261,31 @@ export function createHead(title, description, options = {}) {
         dateModified: new Date().toISOString()
     };
 
+    head.querySelectorAll('script[type="application/ld+json"][data-jsreact-structured]')
+        .forEach(script => script.remove());
+
     const scriptLD = document.createElement('script');
     scriptLD.type = 'application/ld+json';
+    scriptLD.dataset.jsreactStructured = 'true';
     scriptLD.textContent = JSON.stringify(structuredData);
     head.appendChild(scriptLD);
 
-    // Show content when styles are loaded
-    document.body.classList.add('js-ready');
+    const markBodyReady = () => {
+        if (document.body) {
+            document.body.classList.add('js-ready');
+        }
+    };
 
-    return { title, description };
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', markBodyReady, { once: true });
+    } else {
+        markBodyReady();
+    }
+
+    return { title, description, canonicalUrl };
+}
+
+if (typeof window !== 'undefined') {
+    window.createHead = createHead;
+    window.createHeader = createHeader;
 }

--- a/src/diff/index.html
+++ b/src/diff/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <script type="module">
             import { createHead } from '@components/head.js';
             createHead(

--- a/src/domain/index.html
+++ b/src/domain/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
         <!-- Tailwind CSS is handled by Vite/PostCSS, CDN removed -->
         <!-- Tailwind CSS (if not already included globally) -->

--- a/src/elevation/index.html
+++ b/src/elevation/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <title>Elevation Finder - Find Elevation Data for Any Location | JSreact</title>
         <meta name="description"
             content="Find elevation data for any location using address search or map clicking. Free online elevation finder tool with interactive maps.">

--- a/src/expression/index.html
+++ b/src/expression/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <script type="module">
             import { createHead } from '@components/head.js';
             createHead(

--- a/src/generator/index.html
+++ b/src/generator/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <script type="module">
             import { createHead } from '@components/head.js';
             createHead(

--- a/src/insert/index.html
+++ b/src/insert/index.html
@@ -5,13 +5,14 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Natural Keyword Inserter</title>
-        <link rel="icon" href="/public/favicon.ico" type="image/x-icon" />
+        <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
         <!-- Tailwind CSS -->
         <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet" />
 
-        <script type="module" src="@components/head.js"></script>
-        <script>
+        <script type="module">
+            import { createHead } from '@components/head.js';
+
             createHead(
                 'Insert Tool - Text Insertion and Manipulation',
                 'Insert and manipulate text with powerful tools. Format, process, and modify text content easily.'

--- a/src/keyword/index.html
+++ b/src/keyword/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
         <!-- Production-ready Tailwind CSS -->
         <script src="https://cdn.tailwindcss.com"></script>

--- a/src/minify/index.html
+++ b/src/minify/index.html
@@ -2,9 +2,10 @@
 <html lang="en" class="scroll-smooth">
 
     <head>
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
-        <script type="module" src="@components/head.js"></script>
-        <script>
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
+        <script type="module">
+            import { createHead } from '@components/head.js';
+
             createHead(
                 'JavaScript, CSS & HTML Minifier - Free Online Code Compression Tool',
                 'Free online tool to minify and optimize JavaScript, CSS, and HTML code. Reduce file size up to 80%, improve load times, and enhance website performance with advanced Terser compression. Best free code minifier with source map support.'

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
         <!-- Tailwind CSS is handled by Vite/PostCSS, CDN removed -->
         <!-- Tailwind CSS (if not already included globally) -->

--- a/src/policy/index.html
+++ b/src/policy/index.html
@@ -2,9 +2,10 @@
 <html lang="en" class="scroll-smooth dark">
 
     <head>
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
-        <script type="module" src="@components/head.js"></script>
-        <script>
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
+        <script type="module">
+            import { createHead } from '@components/head.js';
+
             createHead(
                 'Privacy Policy',
                 'JSreact Privacy Policy - Our commitment to protecting your data and privacy. Learn about our data collection, usage, and security practices.'
@@ -12,10 +13,10 @@
         </script>
     </head>
 
-    <body class="bg-gray-50 
-        <script type=" module">
-        import { createNavbar } from '@components/navbar.js';
-        createNavbar();
+    <body class="bg-gray-50">
+        <script type="module">
+            import { createNavbar } from '@components/navbar.js';
+            createNavbar();
         </script>
 
         <div id="header"></div>

--- a/src/speech/index.html
+++ b/src/speech/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="scroll-smooth">
 
     <head>
-        <link rel="icon" type="image/x-icon" href="/public/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <script type="module">
             import { createHead } from '@components/head.js';
             createHead(


### PR DESCRIPTION
## Summary
- normalize canonical link handling in the shared head helper so meta tags persist, structured data stays accurate, and a single canonical URL is emitted
- load the head helper correctly on tool and policy pages while fixing favicon paths that previously pointed at /public
- regenerate and sync the sitemap with curated entries by updating the generation script

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d227fd12c0832e95981467cd6b19f8