### PR TITLE
Improve SEO metadata and redirects

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,103 +2,121 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://jsreact.com/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://jsreact.com/analytics/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/clean/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/diff/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/domain/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/elevation/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/expression/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/generator/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/insert/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/keyword/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/minify/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/numigma/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/osrs-flip-finder/</loc>
+    <lastmod>2025-10-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/osrs-flipping-tool/</loc>
+    <lastmod>2025-10-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jsreact.com/osrs-flipping-tools/</loc>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/osrs/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/playground/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/policy/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/qr/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jsreact.com/speech/</loc>
-    <lastmod>2025-10-21</lastmod>
+    <lastmod>2025-10-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/clean/index.html
+++ b/src/clean/index.html
@@ -9,7 +9,11 @@
             import { createHead } from '@components/head.js';
             createHead(
                 'Online Text Cleaner & Formatter',
-                'Clean and format text with our advanced text processing tool'
+                'Clean and format text with our advanced text processing tool',
+                {
+                    canonicalPath: '/clean/',
+                    keywords: 'text cleaner, text formatter, whitespace cleanup, string normalizer, content cleaner, text processing tool, remove extra spaces, clean text online, format text tool, text editor'
+                }
             );
         </script>
 
@@ -421,6 +425,85 @@
                     </section>
                 </div>
             </div>
+
+            <section class="mt-12 space-y-8">
+                <article class="bg-white border border-gray-200 rounded-2xl shadow-md p-8">
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-4">
+                        Why our text cleaner beats copy-paste fixes
+                    </h2>
+                    <p class="text-gray-600 leading-relaxed">
+                        Copying text from documents, emails, or PDFs usually drags in messy formatting. Our clean text tool
+                        removes invisible characters, tames whitespace, and normalizes punctuation so your content is ready for
+                        CMS editors, newsletters, and code repositories. Instead of manually cleaning copy-pasted text, toggle the
+                        options you need and watch the output update instantly.
+                    </p>
+                    <ul class="mt-5 grid gap-3 sm:grid-cols-2 list-disc list-inside text-gray-600">
+                        <li>One-click removal of stray spaces, tabs, and extra line breaks</li>
+                        <li>Optional smart punctuation fixes for quotes, dashes, and ellipses</li>
+                        <li>Regex powered find-and-replace for surgical content edits</li>
+                        <li>Presets for writers, developers, and marketing teams</li>
+                    </ul>
+                </article>
+
+                <article class="bg-white border border-gray-200 rounded-2xl shadow-md p-8">
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-4">
+                        How to clean copy-pasted text before publishing
+                    </h2>
+                    <div class="grid gap-6 lg:grid-cols-2">
+                        <div class="space-y-3 text-gray-600">
+                            <p>
+                                Paste your content into the input panel, enable the cleaning steps you want, and click
+                                <span class="font-medium text-gray-900">Clean Text</span>. The output panel keeps formatting you
+                                intentionally applied while stripping the junk. Use the live counters to verify how many matches were
+                                replaced so you know every instance was handled.
+                            </p>
+                            <p>
+                                Working with Markdown or HTML? Keep punctuation normalization on, but disable punctuation removal so
+                                important characters remain untouched. The tool remembers your choices, making repetitive clean-ups
+                                effortless.
+                            </p>
+                        </div>
+                        <div class="bg-gray-50 border border-gray-200 rounded-xl p-6 space-y-4 text-gray-700">
+                            <h3 class="text-lg font-semibold text-gray-900">Popular use cases</h3>
+                            <ul class="list-disc list-inside space-y-2">
+                                <li>Preparing email newsletters copied from Word or Google Docs</li>
+                                <li>Cleaning blog posts before pasting into CMS editors</li>
+                                <li>Normalizing user generated content or support ticket text</li>
+                                <li>Fixing spacing issues in JSON, YAML, or configuration snippets</li>
+                            </ul>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="bg-white border border-gray-200 rounded-2xl shadow-md p-8">
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-4">Frequently asked questions</h2>
+                    <div class="space-y-6 text-gray-600">
+                        <div>
+                            <h3 class="text-lg font-semibold text-gray-900">Can I keep intentional spacing and indentation?</h3>
+                            <p>
+                                Yes. Disable the <span class="font-medium text-gray-900">Remove Extra Spaces</span> option to preserve
+                                indentation while still trimming stray whitespace at the ends of lines. Developers often pair this with
+                                punctuation normalization for clean, readable snippets.
+                            </p>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-gray-900">Does the cleaner support accented characters?</h3>
+                            <p>
+                                All operations run on Unicode-safe utilities, so characters from non-English languages, emojis, and
+                                mathematical symbols remain intact while the tool removes only the unwanted formatting noise.
+                            </p>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-gray-900">How is this different from basic text editors?</h3>
+                            <p>
+                                Editors like Notepad can strip formatting, but they do not normalize quotes, whitespace, or hyphen types.
+                                JSreact's cleaner bundles these adjustments, offers instant previews, and lets you copy the cleaned text
+                                back to your clipboard in a single click.
+                            </p>
+                        </div>
+                    </div>
+                </article>
+            </section>
         </main>
 
         <script type="module" src="@components/footer.js"></script>

--- a/src/components/head.js
+++ b/src/components/head.js
@@ -1,6 +1,30 @@
 // Import styles
 import '@styles/global.css';
 
+const redirectMap = Object.freeze({
+    '/osrs-flip-finder': '/osrs/',
+    '/osrs-flip-finder/': '/osrs/',
+    '/osrs-flipping-tool': '/osrs/',
+    '/osrs-flipping-tool/': '/osrs/',
+    '/osrs-flipping-tools': '/osrs/',
+    '/osrs-flipping-tools/': '/osrs/'
+});
+
+const hasFileExtension = (pathname) => /\.[a-zA-Z0-9]{2,}$/.test(pathname);
+
+const ensureLeadingSlash = (path) => {
+    if (!path) return '/';
+    return path.startsWith('/') ? path : `/${path}`;
+};
+
+const ensureTrailingSlash = (pathname) => {
+    if (!pathname || pathname === '/') return '/';
+    if (pathname.endsWith('/') || hasFileExtension(pathname)) {
+        return pathname;
+    }
+    return `${pathname}/`;
+};
+
 // Export header creation function
 export function createHeader(title, description) {
     const header = document.createElement('header');
@@ -54,11 +78,19 @@ export function createHead(title, description, options = {}) {
         return null;
     }
 
+    const currentUrl = new URL(window.location.href);
+
     const {
         gaTrackingId = 'G-ZEFG04PXR7',
         baseUrl: providedBaseUrl,
         publishDate = new Date().toISOString().split('T')[0],
-        canonicalPath
+        canonicalPath,
+        canonicalUrl: canonicalUrlOverride,
+        redirectToCanonical = true,
+        manualRedirects = true,
+        keywords,
+        additionalMeta = [],
+        structuredData: structuredDataOverride
     } = options;
 
     const defaultBaseUrl = providedBaseUrl ||
@@ -74,6 +106,22 @@ export function createHead(title, description, options = {}) {
             return `${defaultBaseUrl}${path}`;
         }
     };
+
+    const normalizedCurrentPath = ensureTrailingSlash(currentUrl.pathname);
+
+    if (manualRedirects) {
+        const redirectTarget = redirectMap[currentUrl.pathname] || redirectMap[normalizedCurrentPath];
+        if (redirectTarget) {
+            const targetUrl = redirectTarget.startsWith('http')
+                ? redirectTarget
+                : getFullUrl(redirectTarget);
+
+            if (targetUrl !== currentUrl.toString()) {
+                window.location.replace(targetUrl);
+                return null;
+            }
+        }
+    }
 
     const ensureCriticalStyles = () => {
         if (head.querySelector('style[data-jsreact-critical="true"]')) {
@@ -185,18 +233,47 @@ export function createHead(title, description, options = {}) {
         { type: 'link', rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: 'anonymous' }
     ].forEach(appendExternalResource);
 
-    const currentUrl = new URL(window.location.href);
-    let canonicalTarget = canonicalPath || currentUrl.pathname;
-    if (!canonicalTarget.endsWith('/') && !canonicalTarget.includes('.')) {
-        canonicalTarget += '/';
-    }
-    const canonicalUrl = getFullUrl(canonicalTarget);
+    const resolveCanonicalUrl = () => {
+        if (canonicalUrlOverride) {
+            try {
+                return new URL(canonicalUrlOverride, defaultBaseUrl).toString();
+            } catch (e) {
+                console.error('Invalid canonicalUrl override provided', e);
+            }
+        }
+
+        let canonicalTarget = canonicalPath ? ensureLeadingSlash(canonicalPath) : currentUrl.pathname;
+        canonicalTarget = ensureTrailingSlash(canonicalTarget);
+        return getFullUrl(canonicalTarget);
+    };
+
+    const canonicalUrl = resolveCanonicalUrl();
 
     head.querySelectorAll('link[rel="canonical"]').forEach(link => link.remove());
     const canonicalLink = document.createElement('link');
     canonicalLink.rel = 'canonical';
     canonicalLink.href = canonicalUrl;
     head.appendChild(canonicalLink);
+
+    if (redirectToCanonical) {
+        try {
+            const canonical = new URL(canonicalUrl);
+            if (canonical.origin === currentUrl.origin) {
+                const canonicalPathname = ensureTrailingSlash(canonical.pathname);
+                if (normalizedCurrentPath !== canonicalPathname) {
+                    const nextUrl = `${canonicalPathname}${currentUrl.search}${currentUrl.hash}`;
+                    if (window.history && window.history.replaceState) {
+                        window.history.replaceState(null, '', nextUrl);
+                    } else if (nextUrl !== currentUrl.pathname) {
+                        window.location.replace(nextUrl);
+                        return { title, description, canonicalUrl };
+                    }
+                }
+            }
+        } catch (error) {
+            console.error('Failed to normalize canonical URL', error);
+        }
+    }
 
     const metaTags = [
         { charset: 'UTF-8' },
@@ -220,6 +297,17 @@ export function createHead(title, description, options = {}) {
         { name: 'twitter:image', content: getFullUrl('/assets/images/og-image.png') }
     ];
 
+    if (keywords) {
+        const keywordContent = Array.isArray(keywords) ? keywords.join(', ') : keywords;
+        if (keywordContent) {
+            metaTags.push({ name: 'keywords', content: keywordContent });
+        }
+    }
+
+    if (Array.isArray(additionalMeta)) {
+        additionalMeta.filter(Boolean).forEach(meta => metaTags.push(meta));
+    }
+
     metaTags.forEach(setMetaTag);
 
     if (gaTrackingId && !head.querySelector(`script[src*="gtag/js?id=${gaTrackingId}"]`)) {
@@ -239,7 +327,7 @@ export function createHead(title, description, options = {}) {
         head.appendChild(gaInit);
     }
 
-    const structuredData = {
+    const baseStructuredData = {
         '@context': 'https://schema.org',
         '@type': 'WebApplication',
         name: 'JSreact',
@@ -261,14 +349,22 @@ export function createHead(title, description, options = {}) {
         dateModified: new Date().toISOString()
     };
 
+    const structuredData = structuredDataOverride === null
+        ? null
+        : structuredDataOverride
+            ? { ...baseStructuredData, ...structuredDataOverride }
+            : baseStructuredData;
+
     head.querySelectorAll('script[type="application/ld+json"][data-jsreact-structured]')
         .forEach(script => script.remove());
 
-    const scriptLD = document.createElement('script');
-    scriptLD.type = 'application/ld+json';
-    scriptLD.dataset.jsreactStructured = 'true';
-    scriptLD.textContent = JSON.stringify(structuredData);
-    head.appendChild(scriptLD);
+    if (structuredData) {
+        const scriptLD = document.createElement('script');
+        scriptLD.type = 'application/ld+json';
+        scriptLD.dataset.jsreactStructured = 'true';
+        scriptLD.textContent = JSON.stringify(structuredData);
+        head.appendChild(scriptLD);
+    }
 
     const markBodyReady = () => {
         if (document.body) {

--- a/src/elevation/index.html
+++ b/src/elevation/index.html
@@ -61,7 +61,11 @@
             import { createHead } from '@components/head.js';
             createHead(
                 'Elevation Finder - Find Elevation Data for Any Location',
-                'Find elevation data for any location using address search or map clicking. Free online elevation finder tool with interactive maps.'
+                'Find elevation data for any location using address search or map clicking. Free online elevation finder tool with interactive maps.',
+                {
+                    canonicalPath: '/elevation/',
+                    keywords: 'elevation finder, elevation data, topographic data, altitude finder, elevation lookup, geographic elevation, map elevation, terrain elevation'
+                }
             );
         </script>
 
@@ -212,6 +216,92 @@
                     </div>
                 </section>
             </div>
+
+            <section class="mt-12 space-y-8">
+                <article class="bg-card text-card-foreground rounded-xl border border-border/60 shadow-sm p-8">
+                    <h2 class="text-2xl font-semibold mb-3">Why builders and hikers rely on address elevation data</h2>
+                    <p class="text-muted-foreground leading-relaxed">
+                        Accurate elevation lookups influence everything from property development to trail planning. Paste an address,
+                        drop a map pin, or enter coordinates to get instant altitude readings in meters and feet. The tool cross-checks
+                        multiple data sources, which means you can trust the elevation insights whether you're designing a drainage plan
+                        or estimating hiking effort.
+                    </p>
+                    <div class="mt-6 grid gap-4 md:grid-cols-2 text-muted-foreground">
+                        <div class="space-y-2">
+                            <h3 class="text-lg font-semibold text-card-foreground">Popular workflows</h3>
+                            <ul class="list-disc list-inside space-y-1">
+                                <li>Measure address elevation before submitting permit paperwork</li>
+                                <li>Assess flood risks by comparing surrounding terrain heights</li>
+                                <li>Plan hiking routes with realistic ascent and descent expectations</li>
+                                <li>Validate GPS readings for drone operators and survey teams</li>
+                            </ul>
+                        </div>
+                        <div class="space-y-2">
+                            <h3 class="text-lg font-semibold text-card-foreground">Data you can export</h3>
+                            <p>
+                                Copy the coordinate, elevation, and address details in a single click. The clean output is formatted for
+                                spreadsheets, GIS imports, and client reports, making it easy to document elevation checks alongside project
+                                notes.
+                            </p>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="bg-card text-card-foreground rounded-xl border border-border/60 shadow-sm p-8">
+                    <h2 class="text-2xl font-semibold mb-3">Tips for getting precise address elevation results</h2>
+                    <div class="grid gap-6 lg:grid-cols-2 text-muted-foreground">
+                        <div class="space-y-3">
+                            <p>
+                                Start with an exact street address or drop the marker directly on your area of interest. The map supports
+                                satellite and terrain overlays so you can fine-tune the location. When you need to inspect multiple points,
+                                use the refresh button to pull the latest elevation data before saving your notes.
+                            </p>
+                            <p>
+                                Need to reference historical or seasonal changes? Combine our elevation finder with public datasets from USGS,
+                                NASA, or OpenTopo. The structured output makes it easy to compare readings across sources without manual
+                                reformatting.
+                            </p>
+                        </div>
+                        <div class="bg-primary-light/20 border border-primary/20 rounded-xl p-6 space-y-3">
+                            <h3 class="text-lg font-semibold text-card-foreground">Checklist before you export</h3>
+                            <ul class="list-disc list-inside space-y-2">
+                                <li>Verify the pin is centered on the parcel or trail waypoint</li>
+                                <li>Confirm the coordinate precision meets your reporting standards</li>
+                                <li>Switch units between meters and feet for audience-friendly reports</li>
+                                <li>Add nearby landmarks to your notes for easier field navigation</li>
+                            </ul>
+                        </div>
+                    </div>
+                </article>
+
+                <article class="bg-card text-card-foreground rounded-xl border border-border/60 shadow-sm p-8">
+                    <h2 class="text-2xl font-semibold mb-3">Elevation lookup FAQ</h2>
+                    <div class="space-y-5 text-muted-foreground">
+                        <div>
+                            <h3 class="text-lg font-semibold text-card-foreground">How accurate is the elevation data?</h3>
+                            <p>
+                                Elevations come from trusted global datasets with resolutions suited for planning and navigation. For
+                                professional surveys, treat the results as a quick preview before ordering higher-resolution LIDAR or topo
+                                maps.
+                            </p>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-card-foreground">Can I look up elevation for remote locations?</h3>
+                            <p>
+                                Yes. Enter latitude and longitude coordinates, or drop the pin anywhere on the interactive map. The interface
+                                returns the best available data even when no street address exists.
+                            </p>
+                        </div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-card-foreground">Does the tool store my searches?</h3>
+                            <p>
+                                No personal data or lookup history is saved. Everything runs in your browser so you can research project sites
+                                privately and share only the elevation values you choose to export.
+                            </p>
+                        </div>
+                    </div>
+                </article>
+            </section>
         </main>
 
         <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -35,6 +35,10 @@
             createHead(
                 'Web Tools Hub',
                 'A collection of free developer tools to simplify your workflow',
+                {
+                    canonicalPath: '/',
+                    keywords: 'web development tools, online tools, developer utilities, code tools, programming utilities, web tools hub'
+                }
             );
         </script>
         <!-- Enhanced grid overlay background with blur effect -->

--- a/src/osrs-flip-finder/index.html
+++ b/src/osrs-flip-finder/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OSRS Flip Finder Redirect | JSreact</title>
+    <script type="module">
+      import { createHead } from '@components/head.js';
+      createHead(
+        'OSRS Flip Finder Redirect',
+        'Redirecting to the updated OSRS flipping tool with live Grand Exchange analytics.',
+        {
+          canonicalPath: '/osrs/',
+          keywords: ['osrs flip finder', 'osrs flipping tool', 'grand exchange flips'],
+          additionalMeta: [
+            { name: 'robots', content: 'noindex, follow' },
+            { name: 'googlebot', content: 'noindex, follow' }
+          ]
+        }
+      );
+    </script>
+    <meta http-equiv="refresh" content="0; url=/osrs/">
+  </head>
+
+  <body class="bg-background text-foreground flex min-h-screen items-center justify-center">
+    <div class="text-center space-y-3">
+      <p class="text-lg font-medium">Sending you to the OSRS flip finder…</p>
+      <p class="text-sm text-muted-foreground">
+        If you are not redirected automatically, <a href="/osrs/" class="text-primary underline">click here</a>.
+      </p>
+    </div>
+    <script>
+      if (typeof window !== 'undefined' && window.location.pathname !== '/osrs/') {
+        window.location.replace('/osrs/');
+      }
+    </script>
+  </body>
+
+</html>

--- a/src/osrs-flipping-tool/index.html
+++ b/src/osrs-flipping-tool/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OSRS Flip Finder Redirect | JSreact</title>
+    <script type="module">
+      import { createHead } from '@components/head.js';
+      createHead(
+        'OSRS Flip Finder Redirect',
+        'Redirecting to the updated OSRS flipping tool with live Grand Exchange analytics.',
+        {
+          canonicalPath: '/osrs/',
+          keywords: ['osrs flip finder', 'osrs flipping tool', 'grand exchange flips'],
+          additionalMeta: [
+            { name: 'robots', content: 'noindex, follow' },
+            { name: 'googlebot', content: 'noindex, follow' }
+          ]
+        }
+      );
+    </script>
+    <meta http-equiv="refresh" content="0; url=/osrs/">
+  </head>
+
+  <body class="bg-background text-foreground flex min-h-screen items-center justify-center">
+    <div class="text-center space-y-3">
+      <p class="text-lg font-medium">Sending you to the OSRS flip finder…</p>
+      <p class="text-sm text-muted-foreground">
+        If you are not redirected automatically, <a href="/osrs/" class="text-primary underline">click here</a>.
+      </p>
+    </div>
+    <script>
+      if (typeof window !== 'undefined' && window.location.pathname !== '/osrs/') {
+        window.location.replace('/osrs/');
+      }
+    </script>
+  </body>
+
+</html>

--- a/src/osrs-flipping-tools/index.html
+++ b/src/osrs-flipping-tools/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OSRS Flip Finder Redirect | JSreact</title>
+    <script type="module">
+      import { createHead } from '@components/head.js';
+      createHead(
+        'OSRS Flip Finder Redirect',
+        'Redirecting to the updated OSRS flipping tool with live Grand Exchange analytics.',
+        {
+          canonicalPath: '/osrs/',
+          keywords: ['osrs flip finder', 'osrs flipping tool', 'grand exchange flips'],
+          additionalMeta: [
+            { name: 'robots', content: 'noindex, follow' },
+            { name: 'googlebot', content: 'noindex, follow' }
+          ]
+        }
+      );
+    </script>
+    <meta http-equiv="refresh" content="0; url=/osrs/">
+  </head>
+
+  <body class="bg-background text-foreground flex min-h-screen items-center justify-center">
+    <div class="text-center space-y-3">
+      <p class="text-lg font-medium">Sending you to the OSRS flip finder…</p>
+      <p class="text-sm text-muted-foreground">
+        If you are not redirected automatically, <a href="/osrs/" class="text-primary underline">click here</a>.
+      </p>
+    </div>
+    <script>
+      if (typeof window !== 'undefined' && window.location.pathname !== '/osrs/') {
+        window.location.replace('/osrs/');
+      }
+    </script>
+  </body>
+
+</html>

--- a/src/osrs/index.html
+++ b/src/osrs/index.html
@@ -4,9 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OSRS Flipping Tool - Maximize Your Grand Exchange Profits | JSreact</title>
+    <title>OSRS Flip Finder &amp; Flipping Tool - Maximize Grand Exchange Profits | JSreact</title>
     <meta name="description"
-      content="Get real-time flipping suggestions for Old School RuneScape's Grand Exchange. Maximize your profits with our risk-managed OSRS flipping tool.">
+      content="Find profitable OSRS flips with real-time Grand Exchange analytics. Our OSRS flip finder ranks items by profit, speed, and stability for confident trading.">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
     <!-- Styles -->
@@ -19,12 +19,40 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <meta name="keywords"
-      content="osrs flipping, runescape flipping, grand exchange, osrs profit, osrs tools, flipping suggestions, osrs ge, osrs trading, runescape tools, osrs money making">
+      content="osrs flip finder, osrs flipping tool, grand exchange flipping, osrs profit calculator, osrs trading strategies, runescape flipping, osrs ge tool, osrs money making">
     <meta name="author" content="JSreact">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta property="article:tag" content="OSRS Tools">
     <meta property="article:tag" content="Flipping">
     <meta property="article:tag" content="Grand Exchange">
+
+    <script type="module">
+      import { createHead } from '@components/head.js';
+      createHead(
+        'OSRS Flip Finder & Profit Calculator',
+        'Discover high-confidence Old School RuneScape flips with real-time Grand Exchange analytics, profit velocity scoring, and risk controls.',
+        {
+          canonicalPath: '/osrs/',
+          keywords: [
+            'osrs flip finder',
+            'osrs flipping tool',
+            'grand exchange flips',
+            'osrs profit calculator',
+            'osrs merchanting'
+          ],
+          structuredData: {
+            headline: 'OSRS Flip Finder & Profit Calculator',
+            applicationCategory: 'GameApplication',
+            featureList: [
+              'Live Grand Exchange price tracking',
+              'Flip scoring that blends profit, volatility, and confidence',
+              'Searchable buy and sell price database',
+              'Risk controls tailored to your gold budget'
+            ]
+          }
+        }
+      );
+    </script>
   </head>
 
   <body class="bg-background text-foreground flex flex-col min-h-screen">

--- a/src/osrs/osrs.jsx
+++ b/src/osrs/osrs.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
     Paper, TextField, Typography, FormControl, InputLabel, Select, MenuItem,
     Button, ThemeProvider, Box, Container, CssBaseline, CircularProgress, Divider
@@ -112,6 +112,49 @@ export default function OSRSFlipper() {
                 <OsrsGlobalStyles /> {/* Add global styles */}
                 <div className="min-h-screen py-8 px-4 lg:px-8"> {/* Background handled by theme/global styles */}
                     <Container maxWidth="xl" disableGutters>
+                        <Box
+                            component="header"
+                            className="bg-white/80 dark:bg-slate-900/60 border border-slate-200/70 dark:border-slate-700 rounded-2xl p-6 shadow-sm mb-10"
+                        >
+                            <Typography
+                                variant="overline"
+                                sx={{ letterSpacing: 2, color: 'primary.main', fontWeight: 600 }}
+                            >
+                                OSRS Flip Finder
+                            </Typography>
+                            <Typography
+                                variant="h3"
+                                component="h1"
+                                sx={{ mt: 1, color: 'text.primary', fontWeight: 700, fontSize: { xs: '2rem', md: '2.75rem' } }}
+                            >
+                                Real-time Grand Exchange profits tailored to your risk profile
+                            </Typography>
+                            <Typography variant="body1" sx={{ mt: 2, color: 'text.secondary', maxWidth: '65ch' }}>
+                                Use live GE price feeds, volatility checks, and confidence scoring to spot consistent flips before the market
+                                moves. This OSRS flipping tool surfaces deals that align with your budget and trading style so you can scale
+                                profits with fewer risky bets.
+                            </Typography>
+                            <Box className="mt-5 grid gap-3 md:grid-cols-2">
+                                <Box className="rounded-xl border border-primary/20 bg-primary/5 p-4 dark:border-primary/30 dark:bg-primary/10">
+                                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: 'primary.main' }}>
+                                        Profit velocity &amp; stability scoring
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
+                                        Each flip receives a score that blends total profit, execution speed, and risk so you can prioritise the
+                                        most reliable margins first.
+                                    </Typography>
+                                </Box>
+                                <Box className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+                                    <Typography variant="subtitle1" sx={{ fontWeight: 600, color: 'text.primary' }}>
+                                        Searchable buy &amp; sell price intelligence
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
+                                        Look up instant buy or sell suggestions for any item and track recent updates to stay ahead of sudden GE
+                                        swings.
+                                    </Typography>
+                                </Box>
+                            </Box>
+                        </Box>
                         <div className="flex flex-col lg:flex-row gap-6">
 
                             {/* Left Column: Controls & Search */}
@@ -299,6 +342,107 @@ export default function OSRSFlipper() {
                             </div> {/* End Right Column */}
 
                         </div> {/* End Main Flex Container */}
+                        <Box component="section" className="mt-12 space-y-8">
+                            <Paper
+                                elevation={0}
+                                className="p-6 rounded-2xl border border-slate-200/70 bg-white/90 dark:border-slate-700 dark:bg-slate-900/60 space-y-3"
+                            >
+                                <Typography variant="h5" component="h2" sx={{ color: 'text.primary', fontWeight: 700 }}>
+                                    What makes this OSRS flip finder different?
+                                </Typography>
+                                <Typography variant="body1" sx={{ color: 'text.secondary', maxWidth: '72ch' }}>
+                                    Instead of static price tables, this OSRS flipping tool analyses buy limits, trade volumes, volatility, and
+                                    recent GE shifts to rank items by profit velocity. That means you focus on reliable spreads instead of chasing
+                                    outdated margins.
+                                </Typography>
+                                <Box component="ul" className="grid gap-2 sm:grid-cols-2 list-disc list-inside">
+                                    <Typography component="li" variant="body2" sx={{ color: 'text.secondary' }}>
+                                        Dynamic scoring rewards consistent spreads and penalises unstable items
+                                    </Typography>
+                                    <Typography component="li" variant="body2" sx={{ color: 'text.secondary' }}>
+                                        Risk tiers help new merchants avoid tying up gold in thin markets
+                                    </Typography>
+                                    <Typography component="li" variant="body2" sx={{ color: 'text.secondary' }}>
+                                        Confidence percentages blend momentum, margin health, and liquidity signals
+                                    </Typography>
+                                    <Typography component="li" variant="body2" sx={{ color: 'text.secondary' }}>
+                                        Budget controls convert between thousands and millions for every account size
+                                    </Typography>
+                                </Box>
+                            </Paper>
+                            <Paper
+                                elevation={0}
+                                className="p-6 rounded-2xl border border-slate-200/70 bg-white/90 dark:border-slate-700 dark:bg-slate-900/60 space-y-4"
+                            >
+                                <Typography variant="h5" component="h2" sx={{ color: 'text.primary', fontWeight: 700 }}>
+                                    Strategy tips for sustainable GE flipping
+                                </Typography>
+                                <Typography variant="body1" sx={{ color: 'text.secondary' }}>
+                                    Use the search widgets to confirm instant buy and sell prices before placing offers. Combine that insight with
+                                    the profit score and recommended quantity to spread risk across multiple items while keeping your gold in motion.
+                                </Typography>
+                                <Divider sx={{ borderColor: 'divider' }} />
+                                <Box className="grid gap-3 md:grid-cols-2">
+                                    <Box className="space-y-1.5">
+                                        <Typography variant="subtitle1" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                                            Daily routine
+                                        </Typography>
+                                        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                            Check the top flip suggestions, queue medium-risk alternatives, and rotate items every 30-45 minutes to
+                                            avoid hitting GE buy limits.
+                                        </Typography>
+                                    </Box>
+                                    <Box className="space-y-1.5">
+                                        <Typography variant="subtitle1" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                                            When to refresh data
+                                        </Typography>
+                                        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                            Re-run the calculations after game updates, clan events, or whenever profit velocity drops below your
+                                            target gp/hour.
+                                        </Typography>
+                                    </Box>
+                                </Box>
+                            </Paper>
+                            <Paper
+                                elevation={0}
+                                className="p-6 rounded-2xl border border-slate-200/70 bg-white/90 dark:border-slate-700 dark:bg-slate-900/60 space-y-4"
+                            >
+                                <Typography variant="h5" component="h2" sx={{ color: 'text.primary', fontWeight: 700 }}>
+                                    OSRS flipping FAQ
+                                </Typography>
+                                <Box component="dl" className="space-y-4">
+                                    <Box className="space-y-1">
+                                        <Typography component="dt" variant="subtitle1" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                                            How often is the data refreshed?
+                                        </Typography>
+                                        <Typography component="dd" variant="body2" sx={{ color: 'text.secondary' }}>
+                                            The dataset updates throughout the day. Use the refresh button whenever you notice spreads shrinking to pull
+                                            the latest mapping and volume metrics.
+                                        </Typography>
+                                    </Box>
+                                    <Divider sx={{ borderColor: 'divider' }} />
+                                    <Box className="space-y-1">
+                                        <Typography component="dt" variant="subtitle1" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                                            Can I filter for low-risk flips?
+                                        </Typography>
+                                        <Typography component="dd" variant="body2" sx={{ color: 'text.secondary' }}>
+                                            Yes. Lower your budget, then sort by flip score to prioritise items with strong confidence ratings and minimal
+                                            volatility. These are perfect for rebuilding banks without heavy exposure.
+                                        </Typography>
+                                    </Box>
+                                    <Divider sx={{ borderColor: 'divider' }} />
+                                    <Box className="space-y-1">
+                                        <Typography component="dt" variant="subtitle1" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                                            What if a flip stops being profitable?
+                                        </Typography>
+                                        <Typography component="dd" variant="body2" sx={{ color: 'text.secondary' }}>
+                                            Remove the item from your queue and refresh suggestions. The flip finder instantly recalculates rankings so you
+                                            can pivot to faster-moving opportunities without waiting for stale offers to fill.
+                                        </Typography>
+                                    </Box>
+                                </Box>
+                            </Paper>
+                        </Box>
                     </Container>
                 </div>
             </StyledEngineProvider>

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -29,9 +29,7 @@
                     keywords: 'javascript playground, code editor, html editor, css editor, online IDE, react playground, coding environment',
                     baseUrl: 'https://jsreact.com',
                     publishDate: '2025-05-07',
-                    modifiedDate: '2025-05-07',
-                    route: '/playground/',
-                    canonical: 'https://jsreact.com/playground/'
+                    canonicalPath: '/playground/'
                 }
             );
         </script>

--- a/vite.config.js
+++ b/vite.config.js
@@ -80,6 +80,9 @@ export default defineConfig({
                 speech: path.resolve(srcDir, 'speech/index.html'),
                 domain: path.resolve(srcDir, 'domain/index.html'),
                 osrs: path.resolve(srcDir, 'osrs/index.html'),
+                'osrs-flip-finder': path.resolve(srcDir, 'osrs-flip-finder/index.html'),
+                'osrs-flipping-tool': path.resolve(srcDir, 'osrs-flipping-tool/index.html'),
+                'osrs-flipping-tools': path.resolve(srcDir, 'osrs-flipping-tools/index.html'),
                 elevation: path.resolve(srcDir, 'elevation/index.html'),
                 numigma: path.resolve(srcDir, 'numigma/index.html')
             },


### PR DESCRIPTION
## Summary
- expand the shared head helper to normalize canonical URLs, accept keyword metadata, and trigger redirects for legacy OSRS flip finder slugs
- enrich the OSRS flipping experience with a headline hero, strategy guidance, and FAQ content while wiring canonical data through the page
- add substantive copy to the text cleaner and elevation finder tools, and ship redirect placeholder pages plus sitemap updates for new aliases

## Testing
- CI=1 npm run build -- --logLevel warn

------
https://chatgpt.com/codex/tasks/task_e_68f9b01e231c832ea0e89b0f9df84691