### PR TITLE
Expand Numigma clue packs and refresh puzzle UI

### DIFF
--- a/src/numigma/index.html
+++ b/src/numigma/index.html
@@ -51,7 +51,7 @@
                                     </div>
                                     <div class="flex items-center gap-2">
                                         <i class="fas fa-sliders-h"></i>
-                                        <span>11 mix-and-match clue packs</span>
+                                        <span>13 mix-and-match clue packs</span>
                                     </div>
                                 </div>
                             </div>
@@ -67,7 +67,7 @@
                 </section>
 
                 <section
-                    class="bg-white rounded-3xl shadow-lg border border-gray-200 overflow-hidden divide-y divide-gray-100">
+                    class="bg-white numigma-surface overflow-hidden divide-y divide-gray-100">
                     <div class="p-5 sm:p-6 lg:p-8 space-y-6">
                         <div class="space-y-4">
                             <h2 class="text-xl font-semibold text-gray-900 flex items-center gap-2">
@@ -106,12 +106,12 @@
                         <div class="flex flex-col md:flex-row md:items-center justify-between gap-3 text-sm">
                             <div class="flex items-center gap-3">
                                 <button id="copy-share-link"
-                                    class="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 share-link-button">
+                                    class="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 share-link-button numigma-inline-button">
                                     <i class="fas fa-link"></i>
                                     Copy link to current puzzle
                                 </button>
                             </div>
-                            <div class="flex items-center gap-2 text-gray-500" id="range-stats">
+                            <div class="numigma-info-chip text-sm" id="range-stats">
                                 <i class="fas fa-chart-area"></i>
                                 <span>Range size: 0</span>
                             </div>
@@ -120,17 +120,23 @@
 
                     <div class="p-5 sm:p-6 lg:p-8 space-y-5" id="clue-pack-container">
                         <div class="flex flex-col md:flex-row md:items-center justify-between gap-4">
-                            <div>
+                            <div class="space-y-2">
                                 <h3 class="text-lg font-semibold text-gray-900">Clue packs</h3>
                                 <p class="text-sm text-gray-600">Toggle mathematical themes to shape the flavor of the
                                     generated puzzle.</p>
+                                <div id="pack-count-indicator" class="numigma-info-chip text-sm" data-variant="accent">
+                                    <i class="fas fa-boxes-stacked"></i>
+                                    <span>0 of 0 packs enabled</span>
+                                </div>
                             </div>
                             <div class="flex items-center gap-3 text-sm">
-                                <button id="select-all-packs" class="inline-flex items-center gap-2 text-indigo-600 font-semibold">
+                                <button id="select-all-packs"
+                                    class="inline-flex items-center gap-2 text-indigo-600 font-semibold numigma-inline-button">
                                     <i class="fas fa-check-double"></i>
                                     Select all
                                 </button>
-                                <button id="clear-all-packs" class="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900">
+                                <button id="clear-all-packs"
+                                    class="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 numigma-inline-button">
                                     <i class="fas fa-eraser"></i>
                                     Clear
                                 </button>
@@ -141,7 +147,7 @@
                 </section>
 
                 <div id="warning-banner"
-                    class="hidden rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 shadow-sm">
+                    class="hidden numigma-callout border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
                     <div class="flex items-start gap-3">
                         <i class="fas fa-exclamation-triangle mt-1"></i>
                         <div>
@@ -153,7 +159,7 @@
 
                 <section class="grid gap-6 lg:grid-cols-5">
                     <div class="lg:col-span-3 space-y-6">
-                        <div class="bg-white rounded-3xl shadow-lg border border-gray-200">
+                        <div class="bg-white numigma-surface">
                             <div
                                 class="border-b border-gray-100 px-5 py-4 sm:px-6 flex items-center justify-between gap-3">
                                 <h3 class="text-lg font-semibold text-gray-900">Active clues</h3>
@@ -170,7 +176,7 @@
                             </div>
                         </div>
 
-                        <div class="bg-white rounded-3xl shadow-lg border border-gray-200">
+                        <div class="bg-white numigma-surface">
                             <div class="border-b border-gray-100 px-5 py-4 sm:px-6">
                                 <h3 class="text-lg font-semibold text-gray-900">Candidate inspector</h3>
                             </div>
@@ -181,7 +187,7 @@
                     </div>
 
                     <div class="lg:col-span-2 space-y-6">
-                        <div class="bg-white rounded-3xl shadow-lg border border-gray-200">
+                        <div class="bg-white numigma-surface">
                             <div
                                 class="border-b border-gray-100 px-5 py-4 sm:px-6 flex flex-wrap items-center justify-between gap-3">
                                 <h3 class="text-lg font-semibold text-gray-900">Puzzle diagnostics</h3>
@@ -204,7 +210,7 @@
                             </div>
                         </div>
 
-                        <div class="bg-white rounded-3xl shadow-lg border border-gray-200">
+                        <div class="bg-white numigma-surface">
                             <div class="border-b border-gray-100 px-5 py-4 sm:px-6 flex items-center justify-between">
                                 <h3 class="text-lg font-semibold text-gray-900">Solution reveal</h3>
                                 <button id="toggle-solution"

--- a/src/numigma/script.js
+++ b/src/numigma/script.js
@@ -337,6 +337,109 @@ function bellNumbersUpTo(limit) {
         return new Set(bells);
     });
 }
+function sumOfProperDivisors(n) {
+    return sumOfDivisors(n) - n;
+}
+function isPerfectNumber(n) {
+    return memoize(`perfect:${n}`, () => sumOfProperDivisors(n) === n);
+}
+function isSphenic(n) {
+    return memoize(`sphenic:${n}`, () => {
+        const factors = primeFactors(n);
+        if (factors.size !== 3) return false;
+        for (const exp of factors.values()) {
+            if (exp !== 1) {
+                return false;
+            }
+        }
+        return true;
+    });
+}
+function isSquareFree(n) {
+    return memoize(`square-free:${n}`, () => {
+        const factors = primeFactors(n);
+        for (const exp of factors.values()) {
+            if (exp > 1) {
+                return false;
+            }
+        }
+        return true;
+    });
+}
+function mobius(n) {
+    return memoize(`mobius:${n}`, () => {
+        if (n === 1) return 1;
+        const factors = primeFactors(n);
+        for (const exp of factors.values()) {
+            if (exp > 1) {
+                return 0;
+            }
+        }
+        return factors.size % 2 === 0 ? 1 : -1;
+    });
+}
+function describeMobius(mu) {
+    if (mu === 0) {
+        return '0 (not square-free)';
+    }
+    if (mu === 1) {
+        return '1 (square-free with an even number of prime factors)';
+    }
+    if (mu === -1) {
+        return '-1 (square-free with an odd number of prime factors)';
+    }
+    return `${mu}`;
+}
+function largestPrimeFactor(n) {
+    return memoize(`largest-prime-factor:${n}`, () => {
+        let largest = 1;
+        primeFactors(n).forEach((_, prime) => {
+            if (prime > largest) {
+                largest = prime;
+            }
+        });
+        return largest;
+    });
+}
+function reverseNumber(n) {
+    return memoize(`reverse:${n}`, () => Number(n.toString().split('').reverse().join('')));
+}
+function isBinaryPalindrome(n) {
+    return memoize(`binary-pal:${n}`, () => {
+        const representation = n.toString(2);
+        return representation === representation.split('').reverse().join('');
+    });
+}
+const digitFactorials = [
+    1,
+    1,
+    2,
+    6,
+    24,
+    120,
+    720,
+    5040,
+    40320,
+    362880
+];
+function sumOfDigitFactorials(n) {
+    return memoize(`digit-factorials:${n}`, () => digitsOf(n).reduce((acc, digit) => acc + digitFactorials[digit], 0));
+}
+function digitsArithmeticProgressionStep(n) {
+    return memoize(`digit-ap-step:${n}`, () => {
+        const digits = digitsOf(n);
+        if (digits.length < 3) {
+            return null;
+        }
+        const step = digits[1] - digits[0];
+        for (let i = 2; i < digits.length; i += 1) {
+            if (digits[i] - digits[i - 1] !== step) {
+                return null;
+            }
+        }
+        return step;
+    });
+}
 function isHappyNumber(n) {
     return memoize(`happy:${n}`, () => {
         const seen = new Set();
@@ -530,6 +633,28 @@ const cluePackDefinitions = [
                 return createClue('divisibility', 'Divisibility', 3, text, (n) => primeFactors(n).size === factorCount, {
                     key: `prime-factor-count-${factorCount}`
                 });
+            },
+            (ctx) => {
+                const anchors = [
+                    6,
+                    8,
+                    9,
+                    10,
+                    12,
+                    15,
+                    18,
+                    20,
+                    24,
+                    30,
+                    36
+                ];
+                const anchor = anchors[Math.floor(ctx.rng() * anchors.length)];
+                const value = lcm(ctx.target, anchor);
+                if (value === ctx.target) return null;
+                const text = `The lcm with ${anchor} equals ${value}.`;
+                return createClue('divisibility', 'Divisibility', 4, text, (n) => lcm(n, anchor) === value, {
+                    key: `lcm-${anchor}-${value}`
+                });
             }
         ]
     },
@@ -598,6 +723,14 @@ const cluePackDefinitions = [
                 });
             },
             (ctx) => {
+                if (isPrime(ctx.target)) return null;
+                const largest = largestPrimeFactor(ctx.target);
+                const text = `Its largest prime factor is ${largest}.`;
+                return createClue('primes', 'Primes & Factorization', 4, text, (n) => largestPrimeFactor(n) === largest, {
+                    key: `largest-prime-${largest}`
+                });
+            },
+            (ctx) => {
                 if (!isAbundant(ctx.target)) return null;
                 const text = 'It is an abundant number (sum of proper divisors exceeds the number).';
                 return createClue('primes', 'Primes & Factorization', 4, text, (n) => isAbundant(n), {
@@ -656,6 +789,13 @@ const cluePackDefinitions = [
                 const text = `It needs ${length} bit${length === 1 ? '' : 's'} in binary.`;
                 return createClue('binary', 'Binary & Bits', 2, text, (n) => binaryLength(n) === length, {
                     key: `bin-length-${length}`
+                });
+            },
+            (ctx) => {
+                if (!isBinaryPalindrome(ctx.target)) return null;
+                const text = 'Its binary representation is a palindrome.';
+                return createClue('binary', 'Binary & Bits', 4, text, (n) => isBinaryPalindrome(n), {
+                    key: 'binary-palindrome'
                 });
             },
             (ctx) => {
@@ -790,6 +930,42 @@ const cluePackDefinitions = [
         ]
     },
     {
+        id: 'transformations',
+        label: 'Transformations & Patterns',
+        description: 'Digit reversals, factorial sums, and arithmetic progressions.',
+        icon: 'fa-wand-magic-sparkles',
+        default: true,
+        factories: [
+            (ctx) => {
+                const reversed = reverseNumber(ctx.target);
+                if (!isPrime(reversed)) return null;
+                const text = `Reversing its digits yields the prime ${reversed}.`;
+                return createClue('transformations', 'Transformations & Patterns', 4, text, (n) => {
+                    const reversedValue = reverseNumber(n);
+                    return reversedValue === reversed && isPrime(reversedValue);
+                }, {
+                    key: `reverse-prime-${reversed}`
+                });
+            },
+            (ctx) => {
+                const step = digitsArithmeticProgressionStep(ctx.target);
+                if (step === null) return null;
+                const text = `Its digits form an arithmetic progression with step ${step}.`;
+                return createClue('transformations', 'Transformations & Patterns', 4, text, (n) => digitsArithmeticProgressionStep(n) === step, {
+                    key: `digit-ap-${step}`
+                });
+            },
+            (ctx) => {
+                const total = sumOfDigitFactorials(ctx.target);
+                if (total > 2000000) return null;
+                const text = `The sum of the factorials of its digits is ${total}.`;
+                return createClue('transformations', 'Transformations & Patterns', 5, text, (n) => sumOfDigitFactorials(n) === total, {
+                    key: `digit-factorials-${total}`
+                });
+            }
+        ]
+    },
+    {
         id: 'combinatorial',
         label: 'Combinatorial Numbers',
         description: 'Factorials, Catalan numbers, Bell numbers.',
@@ -821,6 +997,37 @@ const cluePackDefinitions = [
         ]
     },
     {
+        id: 'rarities',
+        label: 'Rare Phenomena',
+        description: 'Perfect numbers, square-free values, and sphenic structure.',
+        icon: 'fa-gem',
+        default: true,
+        expensive: true,
+        factories: [
+            (ctx) => {
+                if (!isPerfectNumber(ctx.target)) return null;
+                const text = 'It is a perfect number (equals the sum of its proper divisors).';
+                return createClue('rarities', 'Rare Phenomena', 5, text, (n) => isPerfectNumber(n), {
+                    key: 'perfect-number'
+                });
+            },
+            (ctx) => {
+                if (!isSphenic(ctx.target)) return null;
+                const text = 'It is the product of exactly three distinct primes.';
+                return createClue('rarities', 'Rare Phenomena', 4, text, (n) => isSphenic(n), {
+                    key: 'sphenic'
+                });
+            },
+            (ctx) => {
+                if (!isSquareFree(ctx.target)) return null;
+                const text = 'It is square-free (no prime factor appears more than once).';
+                return createClue('rarities', 'Rare Phenomena', 4, text, (n) => isSquareFree(n), {
+                    key: 'square-free'
+                });
+            }
+        ]
+    },
+    {
         id: 'advanced',
         label: 'Advanced Number Theory',
         description: 'Totients, happy numbers, narcissistic and highly composite numbers.',
@@ -833,6 +1040,14 @@ const cluePackDefinitions = [
                 const text = `Its Euler totient φ(n) equals ${tot}.`;
                 return createClue('advanced', 'Advanced Number Theory', 5, text, (n) => eulerTotient(n) === tot, {
                     key: `totient-${tot}`
+                });
+            },
+            (ctx) => {
+                const value = mobius(ctx.target);
+                const description = describeMobius(value);
+                const text = `Its Möbius function μ(n) is ${description}.`;
+                return createClue('advanced', 'Advanced Number Theory', 5, text, (n) => describeMobius(mobius(n)) === description, {
+                    key: `mobius-${value}`
                 });
             },
             (ctx) => {
@@ -875,6 +1090,7 @@ const elements = {
     cluePackList: document.getElementById('clue-pack-list'),
     selectAll: document.getElementById('select-all-packs'),
     clearAll: document.getElementById('clear-all-packs'),
+    packCountIndicator: document.getElementById('pack-count-indicator'),
     clueList: document.getElementById('clue-list'),
     clueCount: document.getElementById('clue-count'),
     copyClues: document.getElementById('copy-clues-button'),
@@ -1032,8 +1248,11 @@ function escapeHTML(str) {
     });
 }
 const checkboxMap = new Map();
+const packCardMap = new Map();
 function renderCluePacks() {
     elements.cluePackList.innerHTML = '';
+    checkboxMap.clear();
+    packCardMap.clear();
     cluePackDefinitions.forEach((pack) => {
         const wrapper = document.createElement('label');
         wrapper.className = 'numigma-pack';
@@ -1048,8 +1267,18 @@ function renderCluePacks() {
         const content = document.createElement('div');
         content.className = 'space-y-1';
         const heading = document.createElement('div');
-        heading.className = 'pack-heading flex items-center gap-2';
-        heading.innerHTML = `<i class="fas ${pack.icon} text-indigo-500"></i> ${pack.label}`;
+        heading.className = 'pack-heading flex items-center gap-2 flex-wrap';
+        const icon = document.createElement('i');
+        icon.className = `fas ${pack.icon} text-indigo-500`;
+        const title = document.createElement('span');
+        title.textContent = pack.label;
+        heading.append(icon, title);
+        if (pack.expensive) {
+            const badge = document.createElement('span');
+            badge.className = 'pack-badge';
+            badge.textContent = 'Advanced';
+            heading.append(badge);
+        }
         const description = document.createElement('p');
         description.className = "pack-description";
         description.textContent = pack.description;
@@ -1057,9 +1286,34 @@ function renderCluePacks() {
         wrapper.append(checkbox, content);
         elements.cluePackList.appendChild(wrapper);
         checkboxMap.set(pack.id, checkbox);
+        packCardMap.set(pack.id, wrapper);
+        wrapper.classList.toggle('is-active', checkbox.checked);
+        checkbox.addEventListener('change', () => {
+            wrapper.classList.toggle('is-active', checkbox.checked);
+            updatePackCountIndicator();
+            const rangeSize = updateRangeStats();
+            evaluatePerformanceWarnings(rangeSize, getSelectedPacks());
+        });
     });
+    updatePackCountIndicator();
 }
 renderCluePacks();
+syncPackSelectionStyles();
+function syncPackSelectionStyles() {
+    packCardMap.forEach((wrapper, id) => {
+        const checkbox = checkboxMap.get(id);
+        if (!checkbox) return;
+        wrapper.classList.toggle('is-active', checkbox.checked);
+    });
+}
+function updatePackCountIndicator() {
+    if (!elements.packCountIndicator) return;
+    const label = elements.packCountIndicator.querySelector('span');
+    if (!label) return;
+    const total = cluePackDefinitions.length;
+    const selected = getSelectedPacks().length;
+    label.textContent = `${selected} of ${total} packs enabled`;
+}
 function getSelectedPacks() {
     return Array.from(checkboxMap.entries()).filter(([, checkbox]) => checkbox.checked).map(([packId]) => packId);
 }
@@ -1173,6 +1427,8 @@ function parseQueryParameters() {
         checkboxMap.forEach((checkbox, id) => {
             checkbox.checked = packIds.includes(id);
         });
+        syncPackSelectionStyles();
+        updatePackCountIndicator();
     }
     if (params.has('depth')) {
         const depth = Number(params.get('depth'));
@@ -1242,6 +1498,8 @@ elements.selectAll.addEventListener('click', (event) => {
     checkboxMap.forEach((checkbox) => {
         checkbox.checked = true;
     });
+    syncPackSelectionStyles();
+    updatePackCountIndicator();
     evaluatePerformanceWarnings(updateRangeStats(), getSelectedPacks());
     showToast('All clue packs enabled.');
 });
@@ -1250,6 +1508,8 @@ elements.clearAll.addEventListener('click', (event) => {
     checkboxMap.forEach((checkbox) => {
         checkbox.checked = false;
     });
+    syncPackSelectionStyles();
+    updatePackCountIndicator();
     evaluatePerformanceWarnings(updateRangeStats(), getSelectedPacks());
     showToast('Clue packs cleared. Enable at least one to generate.');
 });

--- a/src/numigma/styles.css
+++ b/src/numigma/styles.css
@@ -4,6 +4,84 @@
     --numigma-dark: 15 23 42;
 }
 
+.numigma-surface {
+    position: relative;
+    border-radius: 1.75rem;
+    border: 1px solid rgba(var(--numigma-muted), 0.3);
+    box-shadow: 0 28px 60px -40px rgba(var(--numigma-dark), 0.55),
+        0 22px 48px -36px rgba(var(--numigma-primary), 0.45);
+    overflow: hidden;
+}
+
+.numigma-surface::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(var(--numigma-primary), 0.08), transparent 55%);
+    pointer-events: none;
+    opacity: 0.55;
+}
+
+.numigma-info-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(var(--numigma-muted), 0.35);
+    background: rgba(248, 250, 252, 0.9);
+    color: rgba(var(--numigma-dark), 0.78);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    box-shadow: 0 16px 30px -28px rgba(var(--numigma-dark), 0.6);
+    backdrop-filter: blur(6px);
+}
+
+.numigma-info-chip[data-variant='accent'] {
+    border-color: rgba(var(--numigma-primary), 0.35);
+    background: rgba(var(--numigma-primary), 0.12);
+    color: rgb(var(--numigma-primary));
+    box-shadow: 0 18px 36px -28px rgba(var(--numigma-primary), 0.65);
+}
+
+.numigma-info-chip i {
+    opacity: 0.9;
+}
+
+.numigma-inline-button {
+    padding: 0.4rem 0.95rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.numigma-inline-button:hover {
+    border-color: rgba(var(--numigma-primary), 0.25);
+    box-shadow: 0 16px 32px -30px rgba(var(--numigma-primary), 0.6);
+}
+
+.numigma-inline-button:focus-visible {
+    outline: 2px solid rgba(var(--numigma-primary), 0.35);
+    outline-offset: 2px;
+}
+
+.numigma-callout {
+    position: relative;
+    border-radius: 1.5rem;
+    box-shadow: 0 20px 48px -36px rgba(217, 119, 6, 0.55);
+    overflow: hidden;
+}
+
+.numigma-callout::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.18), transparent 60%);
+    pointer-events: none;
+}
+
 .numigma-input {
     width: 100%;
     padding: 0.75rem 0.875rem;
@@ -79,6 +157,21 @@
     opacity: 0.55;
     cursor: not-allowed;
     pointer-events: none;
+}
+
+.share-link-button {
+    border-radius: 999px;
+    border: 1px solid rgba(var(--numigma-muted), 0.28);
+    background: rgba(248, 250, 252, 0.85);
+    padding: 0.4rem 0.85rem;
+    transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.share-link-button:hover:not([disabled]) {
+    border-color: rgba(var(--numigma-primary), 0.35);
+    background: rgba(255, 255, 255, 0.95);
+    color: rgb(var(--numigma-primary));
+    box-shadow: 0 16px 32px -28px rgba(var(--numigma-primary), 0.6);
 }
 
 .deepen-button {
@@ -178,13 +271,35 @@
     display: flex;
     gap: 0.75rem;
     align-items: flex-start;
+    box-shadow: 0 18px 40px -32px rgba(var(--numigma-dark), 0.55);
     transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.numigma-pack::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(var(--numigma-primary), 0.08);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
 }
 
 .numigma-pack:hover {
     transform: translateY(-2px);
     border-color: rgba(var(--numigma-primary), 0.45);
     box-shadow: 0 12px 30px -18px rgba(var(--numigma-primary), 0.8);
+}
+
+.numigma-pack.is-active {
+    border-color: rgba(var(--numigma-primary), 0.65);
+    box-shadow: 0 18px 38px -24px rgba(var(--numigma-primary), 0.75);
+    background: linear-gradient(135deg, rgba(224, 231, 255, 0.75), rgba(241, 245, 249, 0.95));
+}
+
+.numigma-pack.is-active::before {
+    opacity: 1;
 }
 
 .numigma-pack input[type='checkbox'] {
@@ -198,6 +313,21 @@
     font-weight: 600;
     color: rgb(var(--numigma-dark));
     font-size: 0.95rem;
+}
+
+.pack-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.15rem 0.45rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    border-radius: 999px;
+    background: rgba(var(--numigma-primary), 0.14);
+    color: rgb(var(--numigma-primary));
+    border: 1px solid rgba(var(--numigma-primary), 0.3);
+    margin-left: 0.35rem;
 }
 
 .numigma-pack .pack-description {


### PR DESCRIPTION
## Summary
- add memoized helpers and additional clue factories, including new Transformations & Patterns and Rare Phenomena packs
- surface pack selection feedback with an on-page indicator and dynamic card styling
- refresh the Numigma layout with reusable surface styles, info chips, and updated hero copy

## Testing
- npm run build -- --logLevel warn

------
https://chatgpt.com/codex/tasks/task_e_6903af129ef0832eb0de58853dd91ddc